### PR TITLE
BF: conditioning on too much in forward stepwise, c(mathematical bug …

### DIFF
--- a/selectiveInference/R/funs.fs.R
+++ b/selectiveInference/R/funs.fs.R
@@ -188,7 +188,8 @@ fs <- function(x, y, maxsteps=2000, intercept=TRUE, normalize=TRUE,
 
     if (gi + 2*p > nrow(Gamma)) Gamma = rbind(Gamma,matrix(0,2*p+gbuf,n))
     working_x = t(sign_score*t(working_x))
-    Gamma[gi+Seq(1,p-r),] = t(working_x); gi = gi+p-r
+    #Gamma[gi+Seq(1,p-r),] = t(working_x); gi = gi+p-r
+    Gamma[gi+Seq(1,p-r-1),] = t(working_x[,i_hit]+working_x[,-i_hit]); gi = gi+p-r-1
     Gamma[gi+Seq(1,p-r-1),] = t(working_x[,i_hit]-working_x[,-i_hit]); gi = gi+p-r-1
     Gamma[gi+1,] = t(working_x[,i_hit]); gi = gi+1
 

--- a/selectiveInference/man/fixedLassoInf.Rd
+++ b/selectiveInference/man/fixedLassoInf.Rd
@@ -108,7 +108,7 @@ is not allowed.
 \value{  
 \item{type}{Type of coefficients tested (partial or full)}
 \item{lambda}{Value of tuning parameter lambda used}
-\item{pv}{P-values for active variables}
+\item{pv}{One-sided P-values for active variables, uses the fact we have conditioned on the sign.}
 \item{ci}{Confidence intervals}
 \item{tailarea}{Realized tail areas (lower and upper) for each confidence interval}
 \item{vlo}{Lower truncation limits for statistics}

--- a/selectiveInference/man/fsInf.Rd
+++ b/selectiveInference/man/fsInf.Rd
@@ -82,7 +82,7 @@ to alpha/2, and can be used for error-checking purposes.
 \item{khat}{When type is "active", this is an estimated stopping point
 declared by \code{\link{forwardStop}}; when type is "aic", this is the
 value chosen by the modified AIC scheme}
-\item{pv}{P-values for active variables}
+\item{pv}{One sided P-values for active variables, uses the sign that a variable entered the model with.}
 \item{ci}{Confidence intervals}
 \item{tailarea}{Realized tail areas (lower and upper) for each confidence interval}
 \item{vlo}{Lower truncation limits for statistics}


### PR DESCRIPTION
…rather than code bug); also added a comment about one-sided pvalues

Not sure that all pvalues are always onesided but the ones using polyhedral seem to be by default.